### PR TITLE
EventWaiter-like extension

### DIFF
--- a/src/main/java/gg/amy/catnip/utilities/waiter/EventExtension.java
+++ b/src/main/java/gg/amy/catnip/utilities/waiter/EventExtension.java
@@ -4,31 +4,17 @@ import com.mewna.catnip.extension.AbstractExtension;
 import com.mewna.catnip.shard.EventType;
 import lombok.experimental.Accessors;
 
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-
 /**
  * @author AdrianTodt
  * @since 1/15/18.
  */
 @Accessors(fluent = true)
 public class EventExtension extends AbstractExtension {
-    private final ScheduledExecutorService threadpool;
-
     public EventExtension() {
-        this(Executors.newSingleThreadScheduledExecutor());
-    }
-
-    public EventExtension(ScheduledExecutorService threadpool) {
         super("eventWaiter");
-        this.threadpool = threadpool;
     }
 
     public <T> WaitingEventBuilder<T> waitForEvent(EventType<T> type) {
-        return new WaitingEventBuilder<T>(catnip(), threadpool, type);
-    }
-
-    public void shutdown() {
-        threadpool.shutdown();
+        return new WaitingEventBuilder<T>(catnip(), type);
     }
 }

--- a/src/main/java/gg/amy/catnip/utilities/waiter/EventExtension.java
+++ b/src/main/java/gg/amy/catnip/utilities/waiter/EventExtension.java
@@ -1,0 +1,34 @@
+package gg.amy.catnip.utilities.waiter;
+
+import com.mewna.catnip.extension.AbstractExtension;
+import com.mewna.catnip.shard.EventType;
+import lombok.experimental.Accessors;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+
+/**
+ * @author AdrianTodt
+ * @since 1/15/18.
+ */
+@Accessors(fluent = true)
+public class EventExtension extends AbstractExtension {
+    private final ScheduledExecutorService threadpool;
+
+    public EventExtension() {
+        this(Executors.newSingleThreadScheduledExecutor());
+    }
+
+    public EventExtension(ScheduledExecutorService threadpool) {
+        super("eventWaiter");
+        this.threadpool = threadpool;
+    }
+
+    public <T> WaitingEventBuilder<T> waitForEvent(EventType<T> type) {
+        return new WaitingEventBuilder<T>(catnip(), threadpool, type);
+    }
+
+    public void shutdown() {
+        threadpool.shutdown();
+    }
+}

--- a/src/main/java/gg/amy/catnip/utilities/waiter/EventExtension.java
+++ b/src/main/java/gg/amy/catnip/utilities/waiter/EventExtension.java
@@ -8,7 +8,6 @@ import lombok.experimental.Accessors;
  * @author AdrianTodt
  * @since 1/15/18.
  */
-@Accessors(fluent = true)
 public class EventExtension extends AbstractExtension {
     public EventExtension() {
         super("eventWaiter");

--- a/src/main/java/gg/amy/catnip/utilities/waiter/EventExtension.java
+++ b/src/main/java/gg/amy/catnip/utilities/waiter/EventExtension.java
@@ -2,7 +2,6 @@ package gg.amy.catnip.utilities.waiter;
 
 import com.mewna.catnip.extension.AbstractExtension;
 import com.mewna.catnip.shard.EventType;
-import lombok.experimental.Accessors;
 
 /**
  * @author AdrianTodt

--- a/src/main/java/gg/amy/catnip/utilities/waiter/WaitingEventBuilder.java
+++ b/src/main/java/gg/amy/catnip/utilities/waiter/WaitingEventBuilder.java
@@ -48,12 +48,14 @@ public class WaitingEventBuilder<T> {
 
     public MessageConsumer<T> action(Consumer<T> action) {
         MessageConsumer<T> consumer = catnip.on(type);
-        Long timerId;
 
-        if (timeout > 0 && unit != null) {
+        Long timerId;
+        if(timeout > 0 && unit != null) {
             timerId = catnip.vertx().setTimer(unit.toMillis(timeout), __ -> {
                 consumer.unregister();
-                if (timeoutAction != null) timeoutAction.run();
+                if(timeoutAction != null) {
+                    timeoutAction.run();
+                }
             });
         } else {
             timerId = null;
@@ -61,9 +63,13 @@ public class WaitingEventBuilder<T> {
 
         consumer.handler(message -> {
             T body = message.body();
-            if (condition != null && !condition.test(body)) return;
+            if(condition != null && !condition.test(body)) {
+                return;
+            }
             consumer.unregister();
-            if (timerId != null) catnip.vertx().cancelTimer(timerId);
+            if(timerId != null) {
+                catnip.vertx().cancelTimer(timerId);
+            }
             action.accept(body);
         });
 

--- a/src/main/java/gg/amy/catnip/utilities/waiter/WaitingEventBuilder.java
+++ b/src/main/java/gg/amy/catnip/utilities/waiter/WaitingEventBuilder.java
@@ -1,0 +1,78 @@
+package gg.amy.catnip.utilities.waiter;
+
+import com.mewna.catnip.Catnip;
+import com.mewna.catnip.shard.EventType;
+import io.vertx.core.eventbus.MessageConsumer;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+
+/**
+ * @author AdrianTodt
+ * @since 1/15/18.
+ */
+@Accessors(fluent = true)
+@RequiredArgsConstructor()
+public class WaitingEventBuilder<T> {
+    private final Catnip catnip;
+    private final ScheduledExecutorService threadpool;
+    private final EventType<T> type;
+
+    @Getter
+    private long timeout;
+    @Getter
+    private TimeUnit unit;
+    @Getter
+    private Runnable timeoutAction;
+    @Getter
+    @Setter
+    private Predicate<T> condition;
+
+    public WaitingEventBuilder<T> timeout(long timeout, @Nonnull TimeUnit unit) {
+        return timeout(timeout, unit, null);
+    }
+
+    public WaitingEventBuilder<T> timeout(long timeout, @Nonnull TimeUnit unit, @Nullable Runnable timeoutAction) {
+        this.timeout = timeout;
+        this.unit = unit;
+        this.timeoutAction = timeoutAction;
+
+        return this;
+    }
+
+    public MessageConsumer<T> action(Consumer<T> action) {
+        MessageConsumer<T> consumer = catnip.on(type);
+        ScheduledFuture<?> scheduledTimeout;
+
+        if (timeout > 0 && unit != null) {
+            scheduledTimeout = threadpool.schedule(() ->
+            {
+                consumer.unregister();
+                if (timeoutAction != null) timeoutAction.run();
+            }, this.timeout, unit);
+        } else {
+            scheduledTimeout = null;
+        }
+
+        consumer.handler(message -> {
+            T body = message.body();
+            if (condition != null && !condition.test(body)) return;
+            consumer.unregister();
+            if (scheduledTimeout != null) {
+                scheduledTimeout.cancel(true);
+            }
+            action.accept(body);
+        });
+
+        return consumer;
+    }
+}


### PR DESCRIPTION
Proposing a EventWaiter-like Extension.

- Calling `.action(action)` method builds the waiting event.
- Not specifying a `condition` will make the `action` receive the next event.

Example call:
```java
eventExtension.waitForEvent(/* EventType<T> */ type)
    .timeout(/* long */ timeout, /* TimeUnit */ unit, /* @Nullable Runnable */ timeoutAction)
    .condition(/* Predicate<T> */ condition)
    .action(/* Consumer<T> */ action);
```