### PR TITLE
Generalize the used emojis

### DIFF
--- a/src/main/java/gg/amy/catnip/utilities/menu/MenuEmoji.java
+++ b/src/main/java/gg/amy/catnip/utilities/menu/MenuEmoji.java
@@ -19,7 +19,7 @@ import lombok.experimental.Accessors;
 public class MenuEmoji {
     private String leftArrow = "⬅";
     private String rightArrow = "➡";
-    private String accept = "yes:437708741798920229";
-    private String cancel = "xmark:392356116102774786";
+    private String accept = "✅";
+    private String cancel = "\uD83D\uDEAB";
     private String refresh = "\uD83D\uDD04";
 }


### PR DESCRIPTION
The emojis that were previously used for accept and cancel, were part of a private Discord server and therefore resulted in an error to be thrown when creating reaction menus with the default implementation of the MenuEmoji